### PR TITLE
Added a Dockerfile for the mitm proxy

### DIFF
--- a/Dockerfile.mitm
+++ b/Dockerfile.mitm
@@ -1,0 +1,7 @@
+FROM node:10-slim
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install --only=production
+COPY . .
+EXPOSE 8082
+CMD [ "npm", "run", "start-mitm" ]

--- a/README.md
+++ b/README.md
@@ -45,3 +45,5 @@ This should be perfectly safe.
 
 To build an image for the MITM proxy, simply run `npm run docker-mitm`, and then create a container binding the port 8082 and the folder `/usr/src/app/certs` to the host to get access to the certificates.
 The port 8082 is exposed by Docker for easier setup using a reverse-proxy.
+For example:
+```docker run -d --name=Spotify-adblock --volume=/opt/spotify-adblock/certs:/usr/src/app/certs -p 8082:8082 --restart=always spotify-adblock:latest```, where /opt/spotify-adblock/certs is the path on the host machine where you will find the certificates you need to import.

--- a/README.md
+++ b/README.md
@@ -40,3 +40,8 @@ root certificate at `certs/certs/ca.crt`
 On MacOS, you can trust the root certficate with one command: `sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain certs/certs/ca.crt`
 
 This should be perfectly safe.
+
+# Docker image
+
+To build an image for the MITM proxy, simply run `npm run docker-mitm`, and then create a container binding the port 8082 and the folder `/usr/src/app/certs` to the host to get access to the certificates.
+The port 8082 is exposed by Docker for easier setup using a reverse-proxy.

--- a/README.md
+++ b/README.md
@@ -45,5 +45,9 @@ This should be perfectly safe.
 
 To build an image for the MITM proxy, simply run `npm run docker-mitm`, and then create a container binding the port 8082 and the folder `/usr/src/app/certs` to the host to get access to the certificates.
 The port 8082 is exposed by Docker for easier setup using a reverse-proxy.
+
 For example:
-```docker run -d --name=Spotify-adblock --volume=/opt/spotify-adblock/certs:/usr/src/app/certs -p 8082:8082 --restart=always spotify-adblock:latest```, where /opt/spotify-adblock/certs is the path on the host machine where you will find the certificates you need to import.
+
+```docker run -d --name=Spotify-adblock --volume=/opt/spotify-adblock/certs:/usr/src/app/certs -p 8082:8082 --restart=always spotify-adblock:latest```
+
+,where /opt/spotify-adblock/certs is the path on the host machine where you will find the certificates you need to import.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node index.js"
+    "start": "node index.js",
+    "start-mitm": "node mitm.js",
+    "docker-mitm":"docker build -t spotify-adblock . -f Dockerfile.mitm"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This pull request adds a Dockerfile for the mitm proxy (mitm.js) to deploy it easily on an external server using Docker. I tested it on macOS with Docker Desktop and on Debian 10, it builds and runs perfectly. 