### PR TITLE
Allow unknown domains to fix Podcast functionality

### DIFF
--- a/mitm-utils/blacklist-mitm.js
+++ b/mitm-utils/blacklist-mitm.js
@@ -1,6 +1,11 @@
 const blacklist = [
   "https://spclient.wg.spotify.com/ads/**",
-  "https://spclient.wg.spotify.com/ad-logic/*"
+  "https://spclient.wg.spotify.com/ad-logic/**",
+  "https://spclient.wg.spotify.com/gabo-receiver-service/**",
+  "https://spclient.wg.spotify.com/sponsoredplaylist/**",
+  "**/*sentry.io*/**",
+  "**/*googleapis*/**",
+  "**/*doubleclick*/**",
 ];
 
 module.exports = blacklist;

--- a/mitm.js
+++ b/mitm.js
@@ -61,9 +61,9 @@ mitm_proxy.onConnect(function(req, socket, head, callback) {
   } 
 
   // okay, we have no idea what this is, so
-  // we'll just block this
+  // handle using blacklist
   else {
-    console.log(("Blocking: " + host + ", " + port).red);
+    return callback();
   }
 });
 
@@ -75,6 +75,7 @@ mitm_proxy.onRequest(function(ctx, callback) {
     console.log(("Blocked: " + completeUrl).red);
     ctx.proxyToClientResponse.end(''); // terminate it
   } else {
+    console.log(("Allowing: " + completeUrl).green);
     return callback();
   }
 });


### PR DESCRIPTION
I've noticed the current implementation breaks functionality for podcast audio. Looking into the logs, it appears to be due to some podcasts retrieving audio data directly from the publisher's domains.

For example, NPR podcasts send requests to `edgeX.pod.npr.org`, and New York Times uses `nyt.simplecastaudio.com`:
![image](https://user-images.githubusercontent.com/15202629/217938223-4a3808aa-5ae9-42b6-8ab3-a2617e0b1db4.png)

Since these domains do not appear in either the whitelist or blacklist, they are [blocked by `mitm.js`](https://github.com/AnanthVivekanand/spotify-adblock/blob/d2b6397369adc7607084a29abfca5dcde067adc4/mitm.js#L63-L68).

Seeing as there's no way to possibly whitelist every one of these publisher domains, the only workaround I can think of is to allow unknown domains by default, and update `blacklist-mitm.js` accordingly whenever an advertisement request slips through. I've added the following domains to the blacklist based on what was previously blocked as an unknown domain that would otherwise now be allowed:

- `spclient.wg.spotify.com/gabo-receiver-service/**` (Spotify user data tracking)
- `spclient.wg.spotify.com/sponsoredplaylist/**` (blocks the "sponsered by" visual ads in playlists)
- `**/*sentry.io*/**` (user data tracking)
- `**/*googleapis*/**` (user data tracking)
- `**/*doubleclick*/**` (ads)

I've been using this updated version for a few weeks now without issues, but welcome any feedback or alternative approach. Thanks so much for maintaining this project!